### PR TITLE
Fix always-on searchbox, modify example

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -96,14 +96,11 @@ html_static_path = ['_static']
 # to template names.
 #
 # The default sidebars (for documents that don't match any pattern) are
-# defined by theme itself.  Builtin themes are using these templates by
-# default: ``['localtoc.html', 'relations.html', 'sourcelink.html',
-# 'searchbox.html']``.
+# defined by theme itself.  
 #
-html_sidebars = {'**': [
-    'util/searchbox.html',
-    'util/sidetoc.html'
-    ]}
+# The default `html_sidebars` of Press theme: ['util/searchbox.html', 'util/sidetoc.html']
+#
+html_sidebars = {'**': ['util/sidetoc.html']}
 
 
 # -- Options for HTMLHelp output ---------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -100,7 +100,10 @@ html_static_path = ['_static']
 # default: ``['localtoc.html', 'relations.html', 'sourcelink.html',
 # 'searchbox.html']``.
 #
-html_sidebars = {'**': ['util/sidetoc.html']}
+html_sidebars = {'**': [
+    'util/searchbox.html',
+    'util/sidetoc.html'
+    ]}
 
 
 # -- Options for HTMLHelp output ---------------------------------------------

--- a/sphinx_press_theme/layout.html
+++ b/sphinx_press_theme/layout.html
@@ -53,7 +53,6 @@
               {%- include "util/extlinks.html" %}
             {% endblock %}
           </navlinks>
-          {%- include "util/searchbox.html" %}
           {%- for sidebartemplate in sidebars %}
             {%- include sidebartemplate %}
           {%- endfor %}

--- a/sphinx_press_theme/theme.conf
+++ b/sphinx_press_theme/theme.conf
@@ -2,7 +2,7 @@
 inherit = basic
 stylesheet = css/theme.css # required by sphinx
 pygments_style = paraiso-dark
-sidebars = util/sidetoc.html
+sidebars = util/searchbox.html, util/sidetoc.html
 
 [options]
 analytics_id =


### PR DESCRIPTION
Not sure if it's intended, but that `{%- include "util/searchbox.html" %}` in `layout.html` makes the search box always there, even if you don't specify it in `conf.py`'s `html_sidebars`. I tested this with the latest commit on the master branch.

This fix makes it possible to opt-in “util/searchbox.html” via `html_sidebars` in `conf.py`, as shown in the modified `conf.py`. (Putting it above `util/sidetoc.html` so it appears above TOC.)