### PR TITLE
Fix Sphinx extensions not working by adding script files

### DIFF
--- a/sphinx_press_theme/layout.html
+++ b/sphinx_press_theme/layout.html
@@ -17,12 +17,13 @@
       {# FIXME: use link-preload #}
       <script type="text/javascript" id="documentation_options" data-url_root="{{ pathto('', 1) }}" src="{{ pathto('_static/documentation_options.js', 1) }}"></script>
 
+      {%- for scriptfile in script_files %}
+        {{ js_tag(scriptfile) }}
+      {%- endfor %}
+      
       {# press js #}
       <script src="{{ pathto('_static/theme-vendors.js', 1)}}"></script>
       <script src="{{ pathto('_static/theme.js', 1)}}" defer></script>
-
-      {# default sphinx - jquery based #}
-      <script type="text/javascript" src="{{ pathto('_static/jquery.js', 1)}}"></script>
     {%- endblock %}
     {%- if pageurl %}
       <link rel="canonical" href="{{ pageurl }}" />


### PR DESCRIPTION
I found that by adding `script_files` in `layout.html`, the Mathjax script is now included correctly, so #12 is fixed. This is just from observing `sphinx_rtd_theme`'s [layout.html](https://github.com/rtfd/sphinx_rtd_theme/blob/master/sphinx_rtd_theme/layout.html)

Interestingly the `<script type="text/javascript" src="{{ pathto('_static/jquery.js', 1)}}"></script>`'s also **already included** in the generated htmls. So this PR removes that.

In fact these are things generated from adding `script_files` (testing on `docs`):
```html
<script type="text/javascript" src="_static/jquery.js"></script>
<script type="text/javascript" src="_static/underscore.js"></script>
<script type="text/javascript" src="_static/doctools.js"></script>
<script type="text/javascript" src="_static/language_data.js"></script>
```