### PR TITLE
Allows custom external links via conf.py

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -36,7 +36,19 @@ See docs on `html_sidebars <http://www.sphinx-doc.org/en/master/usage/configurat
 
   html_sidebars = {'**': ['util/searchbox.html', 'util/sidetoc.html']}
 
+``external_links``
+^^^^^^^^^^^^^^^
 
+If provided creates a Github link to the project's repository in the top right corner:
+
+.. code-block:: python
+
+    html_context = {
+        "external_links": [
+          ("Github", "https://github.com/username/repo"),
+          ("Other", "https://github.com/username/repo")
+        ]
+    }
 
 templates
 =========

--- a/sphinx_press_theme/util/extlinks.html
+++ b/sphinx_press_theme/util/extlinks.html
@@ -1,9 +1,11 @@
 {# external links, i.e. #}
-{#
-<div class="nav-item">
-  <a href="https://github.com/schettino72/sphinx_press_theme"
-     class="nav-link external">
-       Github <outboundlink/>
-  </a>
-</div>
-#}
+{% if external_links %}
+  {% for (label, url) in external_links %}
+    <div class="nav-item">
+      <a href="{{ url }}"
+        class="nav-link external">
+          {{ label }} <outboundlink/>
+      </a>
+    </div>
+  {% endfor %}
+{% endif %}


### PR DESCRIPTION
Very simple change allowing users to define as many external links as they want from conf.py

In conf.py:

```python
html_context = {
        "external_links": [
          ("Github", "https://github.com/username/repo"),
          ("Other", "https://github.com/username/repo")
        ]
    }
```

 Result (top right corner):

![image](https://user-images.githubusercontent.com/1646122/65964287-84541700-e454-11e9-9913-0aa49bf4594f.png)
