### PR TITLE
Removed the name "doit" from templates.

### DIFF
--- a/sphinx_press_theme/util/navbar.html
+++ b/sphinx_press_theme/util/navbar.html
@@ -1,7 +1,7 @@
 <navbar @toggle-sidebar="toggleSidebar">
   <router-link to="{{pathto(master_doc)}}" class="home-link">
     {% if logo %}
-      <img class="logo" src="{{ pathto('_static/' + logo, 1) }}" alt="doit logo"/>
+      <img class="logo" src="{{ pathto('_static/' + logo, 1) }}" alt="logo"/>
     {% else %}
       <span class="site-name">{{ project|e }}</span>
     {% endif %}


### PR DESCRIPTION
Hi.
Thanks for sharing this great Sphinx theme as OSS
(and not to depend on some certain project).

But I found the original project name "doit" on this theme.
It's not so serious issue, but this change make it better (I hope).

I didn't add conf.py parameter to custom this alt text.
Because the text "logo" is not so bad for all of projects.
