### PR TITLE
Check if toc_dict entry exists

### DIFF
--- a/sphinx_press_theme/__init__.py
+++ b/sphinx_press_theme/__init__.py
@@ -116,7 +116,8 @@ def add_toctree_data(app, pagename, templatename, context, doctree):
             if current1:
                 current0 = True
                 # if current, add another level
-                children = app.env.toc_dict[name]['sections']
+                if name in app.env.toc_dict:
+                    children = app.env.toc_dict[name]['sections']
             # add page_toc for current page
             entries.append({
                 'name': name,


### PR DESCRIPTION
I don't quite know why this problem happens and I don't know if my solution is appropriate.

You can reproduce the problem for example in the `docs/` directory of this repo:

1. delete the `build` directory if present from a previous build
1. remove the `html_theme` setting from `source/conf.py` (or change it to some other theme)
1. `make html`
1. restore the original `html_theme` setting
1. `make html`

This raises an exception:

```
Exception occurred:
  File "[...]/sphinx_press_theme/__init__.py", line 119, in add_toctree_data
    children = app.env.toc_dict[name]['sections']
KeyError: 'about'
```