### PR TITLE
add license identifiers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: MIT
+# Copyright Eduardo Naufel Schettino and other contributors.
+
 dist
 __pycache__
 *.egg-info

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020-present Eduardo Naufel Schettino and other contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/THIRD-PARTY.md
+++ b/THIRD-PARTY.md
@@ -1,0 +1,65 @@
+See LICENSE for the main open source license of original code written for sphinx_press_theme.
+
+The remainder of this file reproduces the open source licensing details of other projects that have been imported, incorporated into, or derived into parts of sphinx_press_theme.
+
+In no particular order:
+
+----
+
+sphinx-themes, courtesy of WAKAYAMA Shirou
+https://github.com/sphinx-themes/sphinx-themes.org
+
+Copyright (c) 2018 by the WAKAYAMA Shirou
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+----
+
+vuepress, courtesy of Yuxi (Evan) You
+https://github.com/vuejs/vuepress
+
+Copyright (c) 2018-present, Yuxi (Evan) You
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+----
+
+If we have left anything out, it is unintentional. Please let us know.

--- a/demo/Makefile
+++ b/demo/Makefile
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: MIT
+# Copyright Eduardo Naufel Schettino and other contributors.
+
 # Minimal makefile for Sphinx documentation
 #
 

--- a/demo/conf.py
+++ b/demo/conf.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: MIT
+# Copyright Eduardo Naufel Schettino and other contributors.
+
 # Configuration file for the Sphinx documentation builder.
 #
 # This file only contains a selection of the most common options. For a full

--- a/demo/make.bat
+++ b/demo/make.bat
@@ -1,3 +1,6 @@
+REM SPDX-License-Identifier: MIT
+REM Copyright Eduardo Naufel Schettino and other contributors.
+
 @ECHO OFF
 
 pushd %~dp0

--- a/demo/source/domain.rst
+++ b/demo/source/domain.rst
@@ -1,3 +1,7 @@
+..
+  SPDX-License-Identifier: CC-BY-4.0
+  Copyright Eduardo Naufel Schettino and other contributors.
+
 Domain
 ======
 

--- a/demo/source/extensions.rst
+++ b/demo/source/extensions.rst
@@ -1,3 +1,6 @@
+..
+  SPDX-License-Identifier: CC-BY-4.0
+  Copyright Eduardo Naufel Schettino and other contributors.
 
 Extensions
 ==========

--- a/demo/source/index.rst
+++ b/demo/source/index.rst
@@ -1,3 +1,7 @@
+..
+  SPDX-License-Identifier: CC-BY-4.0
+  Copyright Eduardo Naufel Schettino and other contributors.
+
 Demo
 ====
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: MIT
+# Copyright Eduardo Naufel Schettino and other contributors.
+
 # Minimal makefile for Sphinx documentation
 #
 

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,3 +1,6 @@
+REM SPDX-License-Identifier: MIT
+REM Copyright Eduardo Naufel Schettino and other contributors.
+
 @ECHO OFF
 
 pushd %~dp0

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+# SPDX-License-Identifier: MIT
+# Copyright Eduardo Naufel Schettino and other contributors.
 #
 # Configuration file for the Sphinx documentation builder.
 #

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: MIT
+# Copyright Eduardo Naufel Schettino and other contributors.
+
 from setuptools import setup
 
 with open("README.md", "r") as fh:

--- a/sphinx_press_theme/__init__.py
+++ b/sphinx_press_theme/__init__.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: MIT
+# Copyright Eduardo Naufel Schettino and other contributors.
+
 from os import path
 
 from docutils import nodes

--- a/sphinx_press_theme/static/sphinx_press_theme.css
+++ b/sphinx_press_theme/static/sphinx_press_theme.css
@@ -1,3 +1,6 @@
+/* SPDX-License-Identifier: MIT */
+/* Copyright Eduardo Naufel Schettino and other contributors. */
+
 /*
  *
  * Defines default styles specific to Sphinx Press,

--- a/sphinx_press_theme/theme.conf
+++ b/sphinx_press_theme/theme.conf
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: MIT
+# Copyright Eduardo Naufel Schettino and other contributors.
+
 [theme]
 inherit = basic
 stylesheet = css/theme.css # required by sphinx

--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: MIT
+# Copyright Eduardo Naufel Schettino and other contributors.
+
 .DS_Store
 node_modules
 /dist

--- a/ui/babel.config.js
+++ b/ui/babel.config.js
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright Eduardo Naufel Schettino and other contributors.
+
 module.exports = {
   presets: [
     '@vue/app'

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -1,4 +1,7 @@
 <!DOCTYPE html>
+<!-- SPDX-License-Identifier: MIT -->
+<!-- Copyright Eduardo Naufel Schettino and other contributors. -->
+
 <html>
   <head>
     <meta charset="utf-8">

--- a/ui/src/NavLinks.vue
+++ b/ui/src/NavLinks.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- Copyright Eduardo Naufel Schettino and other contributors. -->
+
 <template>
   <nav
     class="nav-links"

--- a/ui/src/Navbar.vue
+++ b/ui/src/Navbar.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- Copyright Eduardo Naufel Schettino and other contributors. -->
+
 <template>
 <header class="navbar">
   <SidebarButton @toggle-sidebar="$emit('toggle-sidebar')"/>

--- a/ui/src/OutboundLink.vue
+++ b/ui/src/OutboundLink.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- Copyright Eduardo Naufel Schettino and other contributors. -->
+
 <template functional>
   <svg class="icon outbound" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" x="0px" y="0px" viewBox="0 0 100 100" width="15" height="15">
     <path fill="currentColor" d="M18.8,85.1h56l0,0c2.2,0,4-1.8,4-4v-32h-8v28h-48v-48h28v-8h-32l0,0c-2.2,0-4,1.8-4,4v56C14.8,83.3,16.6,85.1,18.8,85.1z"></path>

--- a/ui/src/Page.vue
+++ b/ui/src/Page.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- Copyright Eduardo Naufel Schettino and other contributors. -->
+
 <template>
   <div class="page">
     <slot/>

--- a/ui/src/Sidebar.vue
+++ b/ui/src/Sidebar.vue
@@ -1,3 +1,6 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- Copyright Eduardo Naufel Schettino and other contributors. -->
+
 <template>
   <div class="sidebar">
     <slot></slot>

--- a/ui/src/main.js
+++ b/ui/src/main.js
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright Eduardo Naufel Schettino and other contributors.
+
 import Vue from 'vue'
 
 import './vuepress/styles/theme.styl'

--- a/ui/src/sphinx-theme.styl
+++ b/ui/src/sphinx-theme.styl
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright Eduardo Naufel Schettino and other contributors.
+
 @require './vuepress/styles/config'
 
 /* fix anchor link positioning  for fixed navbar */

--- a/ui/vue.config.js
+++ b/ui/vue.config.js
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright Eduardo Naufel Schettino and other contributors.
+
 module.exports = {
   runtimeCompiler: true,
   filenameHashing: false,


### PR DESCRIPTION
Addresses #32

I kept the MIT license that you cited in your setuptools config, and added a Copyright to "Eduardo Naufel Schettino and other contributors", feel free to change to what you see as more appropriate.

Added a `LICENSE` page and `THIRD-PARTY.md` page to cite where any code may have been sourced from.

Probably overkill, but added SPDX identifiers (https://spdx.org/) where I thought it could be relevant.

This Pull Request does not constitute legal advice, and any legal claims of this project should be validated by the Copyright holders.